### PR TITLE
Update to gtk 0.15

### DIFF
--- a/gtk_liststore_item/Cargo.toml
+++ b/gtk_liststore_item/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gtk_liststore_item"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Agathe Porte <microjoe@microjoe.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -17,18 +17,18 @@ repository = "https://github.com/MicroJoe/gtk_liststore_item"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gtk = "0.14"
-glib = "0.14"
+gtk = "0.15"
+glib = "0.15"
 gtk_liststore_item_derive = { version = "1.2.0", optional = true, path = "../gtk_liststore_item_derive" }
 
 [dev-dependencies]
 gtk_liststore_item_derive = { version = "1.2.0", path = "../gtk_liststore_item_derive" }
-gio = "0.14"
+gio = "0.15"
 rand = "0.8"
 
 # Relm example
-relm = "0.22"
-relm-derive = "0.22"
+relm = "0.23"
+relm-derive = "0.23"
 
 [features]
 default = ["derive"]


### PR DESCRIPTION
Simple, as on the tin: updates to use v0.15.x of the `gtk-rs` crates.